### PR TITLE
Adds Ruby 3.2 to the CI matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", ruby-head, jruby-9.2, jruby-9.3, jruby-head]
+        ruby: ["2.7", "3.0", "3.1", "3.2", ruby-head, jruby-9.3, jruby-9.4, jruby-head]
 
     steps:
     - uses: actions/checkout@v3
@@ -19,6 +19,5 @@ jobs:
       with:
         bundler-cache: true # 'bundle install' and cache gems
         ruby-version: ${{ matrix.ruby }}
-        bundler: 2.3.26
     - name: Run tests
       run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", ruby-head, jruby-9.2, jruby-9.3, jruby-head]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", ruby-head, jruby-9.2, jruby-9.3, jruby-head]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true # 'bundle install' and cache gems
         ruby-version: ${{ matrix.ruby }}
+        bundler: 2.3.26
     - name: Run tests
       run: bundle exec rake

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UpcTools
 
-[![Build Status](https://travis-ci.org/Ibotta/ruby_upc_tools.svg?branch=master)](https://travis-ci.org/Ibotta/ruby_upc_tools)
+[![Build Status](https://github.com/Ibotta/ruby_upc_tools/actions/workflows/ci.yml/badge.svg)](https://github.com/Ibotta/ruby_upc_tools/actions/workflows/ci.yml)
 [![Gem Version](https://badge.fury.io/rb/upc_tools.svg)](https://badge.fury.io/rb/upc_tools)
 
 Utilities to generate, convert and validate UPCs.


### PR DESCRIPTION
Story/Issue Link
-----

Adds Ruby 3.2 to the CI matrix.

Background
-----

Ruby 3.2 has just been released. This ensures that CI runs against that version, and that use of the library in Ruby 3.2 apps is properly supported.

The use of a specific bundler version was required to support Ruby 2.5 in the CI matrix.  Bundler 2.4+ no longer supports Ruby 2.5.

Versioning
-----

This should not require any version change.

